### PR TITLE
Added clone of header and footer on each transformTable

### DIFF
--- a/angu-fixed-header-table.js
+++ b/angu-fixed-header-table.js
@@ -58,6 +58,21 @@
                 }
             });
 
+            // Clone the header and footer again using the shadowed table as reference
+            function recloneHeaderAndFooter () {
+                if (!wrap || !elem) {
+                    return;
+                }
+                var sourceTableElems = wrap.querySelectorAll('table.shadowed thead, table.shadowed tfoot');
+                var destinationTableElems = elem.querySelectorAll('thead, tfoot');
+                for (var i=0; i < sourceTableElems.length; i++) {
+                    destinationTableElems[i].parentNode.replaceChild(
+                        sourceTableElems[i].cloneNode(true),
+                        destinationTableElems[i]
+                    );
+                }
+            }
+
             $timeout(function(){
                 wrap = document.createElement('div');
                 elem.parentNode.insertBefore(wrap, elem);
@@ -106,6 +121,7 @@
             }
 
             function transformTable() {
+                recloneHeaderAndFooter();
                 // reset display styles so column widths are correct when measured below
                 $timeout(function () {
                     if(!$elem.is(':visible')){
@@ -113,7 +129,7 @@
                     }
 
                     var height = ($attrs.tableHeight === 'auto' || !$attrs.tableHeight) ?
-                                        getHeight(wrap) : $attrs.tableHeight;
+                        getHeight(wrap) : $attrs.tableHeight;
 
                     var shadows = wrap.querySelectorAll('table.shadowed');
                     angular.forEach(elem.querySelectorAll('thead, tfoot'), function (cont, index) {


### PR DESCRIPTION
Added clone of header and footer on each transformTable invocation so that the header and footer can be updated dynamically. This is interesting when the fixed header is used on a table that can hide/show its columns.
