### PR TITLE
feat - vertical scroll events

### DIFF
--- a/angu-fixed-header-table.js
+++ b/angu-fixed-header-table.js
@@ -252,13 +252,17 @@
 
             function disableVScrollListener(){
                 triggerLoadingEvent(true);
-                $scrollable.off('scroll', verticalScrollHandler);
+                if($scrollable){
+                    $scrollable.off('scroll', verticalScrollHandler);
+                }
             }
 
             function enableVScrollListener(){
                 $timeout(function(){
                     triggerLoadingEvent(false);
-                    $scrollable.on('scroll', verticalScrollHandler);
+                    if($scrollable){
+                        $scrollable.on('scroll', verticalScrollHandler);
+                    }
                 },100);
             }
 

--- a/angu-fixed-header-table.js
+++ b/angu-fixed-header-table.js
@@ -79,7 +79,6 @@
 
             var elem = $elem[0];
             var wrap, $scrollable, scrollable;
-            var scrollListener;
 
             var checkWindowWidthFlag = false;
             var defineColumnWidthFlag = false;
@@ -290,7 +289,7 @@
                     }
 
                     if(scrollOnTopAction || scrollOnBottomAction){
-                        scrollListener = $scrollable.on('scroll', verticalScrollHandler);
+                        $scrollable.on('scroll', verticalScrollHandler);
                     }
                 });
             }
@@ -325,9 +324,8 @@
                     tableDataLoadedWatch();
                     tableDataLoadedWatch = null;
 
-                    if(scrollListener){
-                        scrollListener();
-                        scrollListener = null;
+                    if(scrollOnTopAction || scrollOnBottomAction){
+                        $scrollable.off('scroll', verticalScrollHandler);
                     }
 
                     //---

--- a/angu-fixed-header-table.js
+++ b/angu-fixed-header-table.js
@@ -333,7 +333,7 @@
                     var currentScroll = $scrollable.scrollTop();
                     var offset = el.position().top + currentScroll;
                     var height = $scrollable.height();
-                    $scrollable.css({position : ''});
+                    $scrollable.css({position : 'absolute'});
 
                     var newTopPosition = 0;
 

--- a/angu-fixed-header-table.js
+++ b/angu-fixed-header-table.js
@@ -194,16 +194,6 @@
                         }
                     }, 50);
 
-                    // TODO: review
-                    // $scrollable.css({
-                    //     display: 'block',
-                    //     minWidth: '100%',
-                    //     overflowX: 'hidden',
-                    //     overflowY: 'auto',
-                    //     position: 'absolute'
-                    // });
-                    //updateViewHeight(true);
-
                     deferred.resolve('done');
                 });
 
@@ -394,7 +384,6 @@
                     }
 
                     $timeout(function(){
-                        logScrollInfo(); // TODO: remove
 
                         redefineScrollPositionFlag = $scope.$apply(scrollOnTopAction);
                         redefineScrollPositionFlag = (
@@ -407,8 +396,6 @@
                             enableVScrollListener();
                         }
 
-                        logScrollInfo(); // TODO: remove
-
                         redefineScrollPositionFlag = null;
                         el = null;
                     });
@@ -419,7 +406,6 @@
                     }
 
                     $timeout(function(){
-                        logScrollInfo(); // TODO: remove
 
                         redefineScrollPositionFlag = $scope.$apply(scrollOnBottomAction);
                         redefineScrollPositionFlag = (
@@ -431,8 +417,6 @@
                         } else {
                             enableVScrollListener();
                         }
-
-                        logScrollInfo(); // TODO: remove
 
                         redefineScrollPositionFlag = null;
                         el = null;

--- a/angu-fixed-header-table.js
+++ b/angu-fixed-header-table.js
@@ -313,7 +313,9 @@
             }
 
             function scrollToPosition(newPosition){
-                $scrollable.animate({scrollTop:newPosition}, 1500, 'swing');
+                if($scrollable){
+                    $scrollable.animate({scrollTop:newPosition}, 1500, 'swing');
+                }
             }
 
             function redefineScrollPosition(position, el){

--- a/angu-fixed-header-table.js
+++ b/angu-fixed-header-table.js
@@ -93,6 +93,8 @@
             var resizeTimeout;
             var viewHeight = 0;
 
+            var shouldIgnoreNgTableAfterReloadDataEvent = false;
+
             var shouldRedefineScrollPosition = false;
             var verticalScrollTimeout;
             var scrollOnTopAction = null;
@@ -224,12 +226,15 @@
             // @begin: scroll
 
             function disableVScrollListener(){
+                shouldIgnoreNgTableAfterReloadDataEvent = true;
                 $scrollable.off('scroll', verticalScrollHandler);
             }
 
             function enableVScrollListener(){
                 $timeout(function(){
+                    shouldIgnoreNgTableAfterReloadDataEvent = false;
                     $scrollable.on('scroll', verticalScrollHandler);
+                    transformTable();
                 },100);
             }
 
@@ -487,7 +492,14 @@
 
                 $($window).on('resize', resizeHandler);
                 var updateTableListener = $scope.$on('fixedHeader:updateTable', delayTransformTable);
-                var afterReloadDataListener = $scope.$on('ngTable:afterReloadData', delayTransformTable);
+
+                // TODO: review
+                // var afterReloadDataListener = $scope.$on('ngTable:afterReloadData', delayTransformTable);
+                var afterReloadDataListener = $scope.$on('ngTable:afterReloadData', function(){
+                    if(!shouldIgnoreNgTableAfterReloadDataEvent){
+                        delayTransformTable();
+                    }
+                });
 
                 // wait for data to load and then transform the table
                 var tableDataLoadedWatch = $scope.$watch(tableDataLoaded, function(isTableDataLoaded) {
@@ -525,6 +537,8 @@
                     defineColumnWidthFlag = null;
                     resizeTimeout = null;
                     viewHeight = null;
+
+                    shouldIgnoreNgTableAfterReloadDataEvent = null;
 
                     delayTransformTable = null;
 

--- a/angu-fixed-header-table.js
+++ b/angu-fixed-header-table.js
@@ -116,7 +116,7 @@
 
             //---
 
-            function triggerLoadingEvent(flag){ // TODO: review
+            function triggerLoadingEvent(flag){
                 $rootScope.$broadcast(EVENTS.FIXED_HEADER.LOADING, flag);
             }
 

--- a/angu-fixed-header-table.js
+++ b/angu-fixed-header-table.js
@@ -358,15 +358,6 @@
                 });
             }
 
-            // TODO: remove
-            function logScrollInfo(){
-                console.log(
-                    'scrollable > scrollTop : ', scrollable.scrollTop,
-                    ' > scrollHeight : ', scrollable.scrollHeight,
-                    ' > clientHeight : ', scrollable.clientHeight
-                );
-            }
-
             function doVerticalScrollCheck(){
                 var el;
                 var offset = 0;

--- a/angu-fixed-header-table.js
+++ b/angu-fixed-header-table.js
@@ -307,19 +307,18 @@
                                     offset - tableHeaderHeight
                                 );
                             }
-                            $scrollable.scrollTop(newTopPosition);
+                            // $scrollable.scrollTop(newTopPosition);
+                            $scrollable.animate({scrollTop:newTopPosition}, '800', 'swing');
                             newTopPosition = null;
                             rowHeight = null;
                             tableHeaderHeight = null;
                             tableHeader = null;
                             break;
                         case SCROLL_POSITION.BOTTOM:
-                            $scrollable.scrollTop(
-                                Math.max(
-                                    0,
-                                    (offset + el.height()) - height
-                                )
-                            );
+                            var newTopPosition = ((offset + el.height()) - height);
+                            // $scrollable.scrollTop(newTopPosition);
+                            $scrollable.animate({scrollTop:newTopPosition}, '800', 'swing');
+                            newTopPosition = null;
                             break;
                     }
 
@@ -328,9 +327,18 @@
                 });
             }
 
+            // TODO: remove
+            function logScrollInfo(){
+                console.log(
+                    'scrollable > scrollTop : ', scrollable.scrollTop,
+                    ' > scrollHeight : ', scrollable.scrollHeight,
+                    ' > clientHeight : ', scrollable.clientHeight
+                );
+            }
+
             function doVerticalScrollCheck(){
                 var el;
-                var offset = 1;
+                var offset = 0;
                 var delta = (
                     scrollable.scrollHeight - scrollable.scrollTop - scrollable.clientHeight
                 );
@@ -340,23 +348,27 @@
                     if(shouldRedefineScrollPosition) {
                         el = getElementOn(SCROLL_POSITION.TOP);
                     }
+                    logScrollInfo(); // TODO: remove
                     $scope.$apply(scrollOnTopAction);
                     if(shouldRedefineScrollPosition) {
                         redefineScrollPosition(SCROLL_POSITION.TOP, el);
                     } else {
                         enableVScrollListener();
                     }
+                    logScrollInfo(); // TODO: remove
                 } else if((delta <= offset) && scrollOnBottomAction){
                     disableVScrollListener();
                     if(shouldRedefineScrollPosition) {
                         el = getElementOn(SCROLL_POSITION.BOTTOM);
                     }
+                    logScrollInfo(); // TODO: remove
                     $scope.$apply(scrollOnBottomAction);
                     if(shouldRedefineScrollPosition) {
                         redefineScrollPosition(SCROLL_POSITION.BOTTOM, el);
                     } else {
                         enableVScrollListener();
                     }
+                    logScrollInfo(); // TODO: remove
                 }
 
                 delta = null;


### PR DESCRIPTION
**changes:**
- add `isBoolean` function on Utils
- define constants at beginning of `fixedHeader` function
- redefine the table height calculation to only on init of directive and when windows height changes
- add vertical scroll support 
  - when scroll on top (`fixed-header-scroll-on-top`)
  - when scroll on bottom (`fixed-header-scroll-on-bottom`)
  - to redefine the scroll position
    - if asked (`fixed-header-scroll-redefine-position`) to first or last element (depends on scroll direction), the element selection by default will select the `tr` tag, but it's possible to define the row class name (`fixed-header-row-classname`) to help the element selection
    - event to redefine to top
